### PR TITLE
Отмена санитизации MODx-тегов в DataGrid

### DIFF
--- a/assets/plugins/CResource/_modx.php
+++ b/assets/plugins/CResource/_modx.php
@@ -7,6 +7,7 @@ $dir = dirname(__FILE__);
 $root_dir = dirname(dirname(dirname($dir)));
 
 define('MODX_API_MODE', true);
+define("IN_MANAGER_MODE", 'true'); //Чтобы не санитизировались данные в таблицах easyUI в Админке
 
 include_once($root_dir . "/index.php");
 


### PR DESCRIPTION
В таблицах невозможно было разместить данные типа [\*pagetitle\*] - [(site_name)], они санитизировались.
Обсуждалось здесь http://modx.im/blog/questions/4798.html